### PR TITLE
Now buildable through cargo + merge sort improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,7 @@
+[package]
+name = "rust-sort"
+version = "0.1.0"
+authors = ["Colin Barré-Brisebois <colinbb@gmail.com>"]
+
 [dependencies]
 rand = "0.4"

--- a/src/bubblesort.rs
+++ b/src/bubblesort.rs
@@ -8,13 +8,12 @@
 // https://en.wikipedia.org/wiki/Bubble_sort
 
 // Externals
-use common::{NUM_VALUES,MAX_RANGE,print_array};
+use common::{NUM_VALUES, MAX_RANGE, print_array};
 
 use rand;
 use rand::distributions::{IndependentSample, Range};
 
-pub fn main()
-{
+pub fn main() {
     // Create the array that will contain all of our values
     let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];
 
@@ -23,8 +22,7 @@ pub fn main()
     let mut rng = rand::thread_rng();
 
     // Initialize the array values to random numbers
-    for n in 0..NUM_VALUES
-    {
+    for n in 0..NUM_VALUES {
         values[n] = range.ind_sample(&mut rng);
     }
 
@@ -34,17 +32,14 @@ pub fn main()
     println!("");
 
     // Sort
-    for _ in 0..NUM_VALUES
-    {
-        for j in 1..NUM_VALUES
-        {
+    for _ in 0..NUM_VALUES {
+        for j in 1..NUM_VALUES {
             // if next value is bigger than previous, swap
-            if values[j-1] > values[j]
-            {
-                let val1 = values[j-1];
+            if values[j - 1] > values[j] {
+                let val1 = values[j - 1];
                 let val2 = values[j];
 
-                values[j-1] = val2;
+                values[j - 1] = val2;
                 values[j] = val1;
             }
         }

--- a/src/bubblesort.rs
+++ b/src/bubblesort.rs
@@ -7,18 +7,13 @@
 // Basic implementation of bubble sort, in rust.
 // https://en.wikipedia.org/wiki/Bubble_sort
 
-#![feature(rustc_private)]
-
 // Externals
-mod common;
-use common::NUM_VALUES;
-use common::MAX_RANGE;
-use common::print_array;
+use common::{NUM_VALUES,MAX_RANGE,print_array};
 
-extern crate rand;
+use rand;
 use rand::distributions::{IndependentSample, Range};
 
-fn main()
+pub fn main()
 {
     // Create the array that will contain all of our values
     let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];

--- a/src/bubblesort.rs
+++ b/src/bubblesort.rs
@@ -14,17 +14,10 @@ use rand;
 use rand::distributions::{IndependentSample, Range};
 
 pub fn main() {
-    // Create the array that will contain all of our values
-    let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];
-
-    // Initialize a random number generator that goes between 0..MAX_RANGE
-    let range = Range::new(0, MAX_RANGE);
-    let mut rng = rand::thread_rng();
-
     // Initialize the array values to random numbers
-    for n in 0..NUM_VALUES {
-        values[n] = range.ind_sample(&mut rng);
-    }
+    let mut values: Vec<u32> = (0..NUM_VALUES)
+        .map(|_| Range::new(0, MAX_RANGE).ind_sample(&mut rand::thread_rng()))
+        .collect();
 
     // Print the original values
     println!("Original:");

--- a/src/common.rs
+++ b/src/common.rs
@@ -7,10 +7,8 @@
 pub const NUM_VALUES: usize = 10;
 pub const MAX_RANGE: u32 = 100;
 
-// Copies an array into another, both of matching dimensions.
-pub fn print_array(src: &[u32; NUM_VALUES]) {
-    for i in 0..NUM_VALUES - 1 {
-        print!("{}, ", src[i]);
+pub fn print_array(src: &[u32]) {
+    for i in src.iter() {
+        print!("{}, ", i);
     }
-    print!("{}", src[NUM_VALUES - 1]);
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -8,11 +8,9 @@ pub const NUM_VALUES: usize = 10;
 pub const MAX_RANGE: u32 = 100;
 
 // Copies an array into another, both of matching dimensions.
-pub fn print_array(src: & [u32; NUM_VALUES])
-{
-    for i in 0..NUM_VALUES-1
-    {
+pub fn print_array(src: &[u32; NUM_VALUES]) {
+    for i in 0..NUM_VALUES - 1 {
         print!("{}, ", src[i]);
     }
-    print!("{}", src[NUM_VALUES-1]);
+    print!("{}", src[NUM_VALUES - 1]);
 }

--- a/src/insertionsort.rs
+++ b/src/insertionsort.rs
@@ -8,13 +8,12 @@
 // https://en.wikipedia.org/wiki/Insertion_sort
 
 // Externals
-use common::{NUM_VALUES,MAX_RANGE,print_array};
+use common::{NUM_VALUES, MAX_RANGE, print_array};
 
 use rand;
 use rand::distributions::{IndependentSample, Range};
 
-pub fn main()
-{
+pub fn main() {
     // Create the array that will contain all of our values
     let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];
 
@@ -23,8 +22,7 @@ pub fn main()
     let mut rng = rand::thread_rng();
 
     // Initialize the array values to random numbers
-    for n in 0..NUM_VALUES
-    {
+    for n in 0..NUM_VALUES {
         values[n] = range.ind_sample(&mut rng);
     }
 
@@ -34,16 +32,14 @@ pub fn main()
     println!("");
 
     // Sort
-    for i in 1..NUM_VALUES
-    {
+    for i in 1..NUM_VALUES {
         let mut j = i;
 
-        while j > 0 && values[j-1] > values[j]
-        {
+        while j > 0 && values[j - 1] > values[j] {
             let val1 = values[j];
-            let val2 = values[j-1];
+            let val2 = values[j - 1];
             values[j] = val2;
-            values[j-1] = val1;
+            values[j - 1] = val1;
 
             j -= 1;
         }

--- a/src/insertionsort.rs
+++ b/src/insertionsort.rs
@@ -14,17 +14,10 @@ use rand;
 use rand::distributions::{IndependentSample, Range};
 
 pub fn main() {
-    // Create the array that will contain all of our values
-    let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];
-
-    // Initialize a random number generator that goes between 0..MAX_RANGE
-    let range = Range::new(0, MAX_RANGE);
-    let mut rng = rand::thread_rng();
-
     // Initialize the array values to random numbers
-    for n in 0..NUM_VALUES {
-        values[n] = range.ind_sample(&mut rng);
-    }
+    let mut values: Vec<u32> = (0..NUM_VALUES)
+        .map(|_| Range::new(0, MAX_RANGE).ind_sample(&mut rand::thread_rng()))
+        .collect();
 
     // Print the original values
     println!("Original:");

--- a/src/insertionsort.rs
+++ b/src/insertionsort.rs
@@ -7,18 +7,13 @@
 // Basic implementation of insertion sort, in rust.
 // https://en.wikipedia.org/wiki/Insertion_sort
 
-#![feature(rustc_private)]
-
 // Externals
-mod common;
-use common::NUM_VALUES;
-use common::MAX_RANGE;
-use common::print_array;
+use common::{NUM_VALUES,MAX_RANGE,print_array};
 
-extern crate rand;
+use rand;
 use rand::distributions::{IndependentSample, Range};
 
-fn main()
+pub fn main()
 {
     // Create the array that will contain all of our values
     let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,19 +7,19 @@ mod mergesort;
 mod selectionsort;
 
 fn main() {
-	println!("bubblesort:");
-	bubblesort::main();	
-	println!("\n--------------------\n");
+    println!("bubblesort:");
+    bubblesort::main();
+    println!("\n--------------------\n");
 
-	println!("insertionsort:");
-	insertionsort::main();	
-	println!("\n--------------------\n");
+    println!("insertionsort:");
+    insertionsort::main();
+    println!("\n--------------------\n");
 
-	println!("mergesort:");
-	mergesort::main();	
-	println!("\n--------------------\n");
+    println!("mergesort:");
+    mergesort::main();
+    println!("\n--------------------\n");
 
-	println!("selectionsort:");
-	selectionsort::main();	
-	println!("\n--------------------\n");
+    println!("selectionsort:");
+    selectionsort::main();
+    println!("\n--------------------\n");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,25 @@
+extern crate rand;
+
+mod common;
+mod bubblesort;
+mod insertionsort;
+mod mergesort;
+mod selectionsort;
+
+fn main() {
+	println!("bubblesort:");
+	bubblesort::main();	
+	println!("\n--------------------\n");
+
+	println!("insertionsort:");
+	insertionsort::main();	
+	println!("\n--------------------\n");
+
+	println!("mergesort:");
+	mergesort::main();	
+	println!("\n--------------------\n");
+
+	println!("selectionsort:");
+	selectionsort::main();	
+	println!("\n--------------------\n");
+}

--- a/src/mergesort.rs
+++ b/src/mergesort.rs
@@ -8,7 +8,7 @@
 // https://en.wikipedia.org/wiki/Merge_sort
 
 // Externals
-use common::{NUM_VALUES,MAX_RANGE,print_array};
+use common::{NUM_VALUES, MAX_RANGE, print_array};
 
 use rand;
 use rand::distributions::{IndependentSample, Range};
@@ -19,59 +19,61 @@ use std::cmp::min;
 // 1. Divide the unsorted list into n-sublists, each containing 1 element. A list of 1 element is considered sorted.
 // 2. Repeatedly merge sublists to produce new sorted sublists until there is only 1 sublist remaining.
 //    This will be the sorted list.
-fn bottom_up_merge_sort(a: &mut [u32; NUM_VALUES])
-{
+fn bottom_up_merge_sort(a: &mut [u32; NUM_VALUES]) {
     // Initialize our work array
     let mut b: [u32; NUM_VALUES] = [0; NUM_VALUES];
 
     let mut width = 1;
-    while width < NUM_VALUES
-    {
+    while width < NUM_VALUES {
         // Array A is full of runs of length width.
         let mut i = 0;
-        while i < NUM_VALUES
-        {
+        while i < NUM_VALUES {
             // Merge two runs: a[i:i+width-1] nd a[i+width:i+2*width-1] to b[]
             // or copy a[i:n-1] to b[] if(i+width >= n)
-            bottom_up_merge(a, i, min(i+width, NUM_VALUES), min(i+2*width, NUM_VALUES), &mut b);
-            i = i + 2*width;
+            bottom_up_merge(
+                a,
+                i,
+                min(i + width, NUM_VALUES),
+                min(i + 2 * width, NUM_VALUES),
+                &mut b,
+            );
+            i = i + 2 * width;
         }
 
         // Now work array B is full of runs of length 2*width.
         // Copy array B to array A for next iteration.
-        for i in 0..NUM_VALUES
-        {
+        for i in 0..NUM_VALUES {
             a[i] = b[i];
         }
         // Now array A is full of runs of length 2*width.
 
         // Make successively longer sorted runs of length 2, 4, 8, 16... until whole array is sorted.
-        width = 2*width;
+        width = 2 * width;
     }
 }
 
-fn bottom_up_merge(a: &mut [u32; NUM_VALUES], i_left: usize, i_right: usize, i_end: usize, b: &mut [u32; NUM_VALUES])
-{
+fn bottom_up_merge(
+    a: &mut [u32; NUM_VALUES],
+    i_left: usize,
+    i_right: usize,
+    i_end: usize,
+    b: &mut [u32; NUM_VALUES],
+) {
     let mut i = i_left;
     let mut j = i_right;
 
-    for k in i_left..i_end
-    {
-        if i < i_right && (j >= i_end || a[i] <= a[j])
-        {
+    for k in i_left..i_end {
+        if i < i_right && (j >= i_end || a[i] <= a[j]) {
             b[k] = a[i];
             i = i + 1;
-        }
-        else
-        {
+        } else {
             b[k] = a[j];
             j = j + 1;
         }
     }
 }
 
-pub fn main()
-{
+pub fn main() {
     // Create the array that will contain all of our values
     let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];
 
@@ -80,8 +82,7 @@ pub fn main()
     let mut rng = rand::thread_rng();
 
     // Initialize the array values to random numbers
-    for n in 0..NUM_VALUES
-    {
+    for n in 0..NUM_VALUES {
         values[n] = range.ind_sample(&mut rng);
     }
 

--- a/src/mergesort.rs
+++ b/src/mergesort.rs
@@ -7,15 +7,10 @@
 // Basic implementation of merge sort, in rust.
 // https://en.wikipedia.org/wiki/Merge_sort
 
-#![feature(rustc_private)]
-
 // Externals
-mod common;
-use common::NUM_VALUES;
-use common::MAX_RANGE;
-use common::print_array;
+use common::{NUM_VALUES,MAX_RANGE,print_array};
 
-extern crate rand;
+use rand;
 use rand::distributions::{IndependentSample, Range};
 use std::cmp::min;
 
@@ -75,7 +70,7 @@ fn bottom_up_merge(a: &mut [u32; NUM_VALUES], i_left: usize, i_right: usize, i_e
     }
 }
 
-fn main()
+pub fn main()
 {
     // Create the array that will contain all of our values
     let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];

--- a/src/mergesort.rs
+++ b/src/mergesort.rs
@@ -19,32 +19,35 @@ use std::cmp::min;
 // 1. Divide the unsorted list into n-sublists, each containing 1 element. A list of 1 element is considered sorted.
 // 2. Repeatedly merge sublists to produce new sorted sublists until there is only 1 sublist remaining.
 //    This will be the sorted list.
-fn bottom_up_merge_sort(a: &mut [u32; NUM_VALUES]) {
+fn bottom_up_merge_sort(a: &mut [u32]) {
     // Initialize our work array
-    let mut b: [u32; NUM_VALUES] = [0; NUM_VALUES];
+    let mut b = vec![0u32; a.len()];
+
+    let len = a.len();
 
     let mut width = 1;
-    while width < NUM_VALUES {
+    while width < len {
         // Array A is full of runs of length width.
         let mut i = 0;
-        while i < NUM_VALUES {
+        while i < len {
             // Merge two runs: a[i:i+width-1] nd a[i+width:i+2*width-1] to b[]
             // or copy a[i:n-1] to b[] if(i+width >= n)
             bottom_up_merge(
                 a,
                 i,
-                min(i + width, NUM_VALUES),
-                min(i + 2 * width, NUM_VALUES),
-                &mut b,
+                min(i + width, len),
+                min(i + 2 * width, len),
+                b.as_mut_slice(),
             );
             i = i + 2 * width;
         }
 
         // Now work array B is full of runs of length 2*width.
         // Copy array B to array A for next iteration.
-        for i in 0..NUM_VALUES {
+        for i in 0..len {
             a[i] = b[i];
         }
+
         // Now array A is full of runs of length 2*width.
 
         // Make successively longer sorted runs of length 2, 4, 8, 16... until whole array is sorted.
@@ -53,11 +56,11 @@ fn bottom_up_merge_sort(a: &mut [u32; NUM_VALUES]) {
 }
 
 fn bottom_up_merge(
-    a: &mut [u32; NUM_VALUES],
+    a: &mut [u32],
     i_left: usize,
     i_right: usize,
     i_end: usize,
-    b: &mut [u32; NUM_VALUES],
+    b: &mut [u32],
 ) {
     let mut i = i_left;
     let mut j = i_right;

--- a/src/mergesort.rs
+++ b/src/mergesort.rs
@@ -53,13 +53,7 @@ fn bottom_up_merge_sort(a: &mut [u32]) {
     }
 }
 
-fn bottom_up_merge(
-    a: &mut [u32],
-    i_left: usize,
-    i_right: usize,
-    i_end: usize,
-    b: &mut [u32],
-) {
+fn bottom_up_merge(a: &mut [u32], i_left: usize, i_right: usize, i_end: usize, b: &mut [u32]) {
     let mut i = i_left;
     let mut j = i_right;
 
@@ -75,17 +69,10 @@ fn bottom_up_merge(
 }
 
 pub fn main() {
-    // Create the array that will contain all of our values
-    let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];
-
-    // Initialize a random number generator that goes between 0..MAX_RANGE
-    let range = Range::new(0, MAX_RANGE);
-    let mut rng = rand::thread_rng();
-
     // Initialize the array values to random numbers
-    for n in 0..NUM_VALUES {
-        values[n] = range.ind_sample(&mut rng);
-    }
+    let mut values: Vec<u32> = (0..NUM_VALUES)
+        .map(|_| Range::new(0, MAX_RANGE).ind_sample(&mut rand::thread_rng()))
+        .collect();
 
     // Print the original values
     println!("Original:");

--- a/src/mergesort.rs
+++ b/src/mergesort.rs
@@ -44,9 +44,7 @@ fn bottom_up_merge_sort(a: &mut [u32]) {
 
         // Now work array B is full of runs of length 2*width.
         // Copy array B to array A for next iteration.
-        for i in 0..len {
-            a[i] = b[i];
-        }
+        a.copy_from_slice(&b);
 
         // Now array A is full of runs of length 2*width.
 

--- a/src/selectionsort.rs
+++ b/src/selectionsort.rs
@@ -7,18 +7,13 @@
 // Basic implementation of selection sort, in rust.
 // https://en.wikipedia.org/wiki/Selection_sort
 
-#![feature(rustc_private)]
-
 // Externals
-mod common;
-use common::NUM_VALUES;
-use common::MAX_RANGE;
-use common::print_array;
+use common::{NUM_VALUES,MAX_RANGE,print_array};
 
-extern crate rand;
+use rand;
 use rand::distributions::{IndependentSample, Range};
 
-fn main()
+pub fn main()
 {
     // Create the array that will contain all of our values
     let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];

--- a/src/selectionsort.rs
+++ b/src/selectionsort.rs
@@ -14,17 +14,10 @@ use rand;
 use rand::distributions::{IndependentSample, Range};
 
 pub fn main() {
-    // Create the array that will contain all of our values
-    let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];
-
-    // Initialize a random number generator that goes between 0..MAX_RANGE
-    let range = Range::new(0, MAX_RANGE);
-    let mut rng = rand::thread_rng();
-
     // Initialize the array values to random numbers
-    for n in 0..NUM_VALUES {
-        values[n] = range.ind_sample(&mut rng);
-    }
+    let mut values: Vec<u32> = (0..NUM_VALUES)
+        .map(|_| Range::new(0, MAX_RANGE).ind_sample(&mut rand::thread_rng()))
+        .collect();
 
     // Print the original values
     println!("Original:");

--- a/src/selectionsort.rs
+++ b/src/selectionsort.rs
@@ -8,13 +8,12 @@
 // https://en.wikipedia.org/wiki/Selection_sort
 
 // Externals
-use common::{NUM_VALUES,MAX_RANGE,print_array};
+use common::{NUM_VALUES, MAX_RANGE, print_array};
 
 use rand;
 use rand::distributions::{IndependentSample, Range};
 
-pub fn main()
-{
+pub fn main() {
     // Create the array that will contain all of our values
     let mut values: [u32; NUM_VALUES] = [0; NUM_VALUES];
 
@@ -23,8 +22,7 @@ pub fn main()
     let mut rng = rand::thread_rng();
 
     // Initialize the array values to random numbers
-    for n in 0..NUM_VALUES
-    {
+    for n in 0..NUM_VALUES {
         values[n] = range.ind_sample(&mut rng);
     }
 
@@ -34,24 +32,20 @@ pub fn main()
     println!("");
 
     // Sort
-    for j in 0..NUM_VALUES-1
-    {
+    for j in 0..NUM_VALUES - 1 {
         // We begin at j
         let mut min = j;
 
         // Find the minimum in the rest of the array, starting at j+1
-        for i in j+1..NUM_VALUES
-        {
-            if values[i] < values[min]
-            {
+        for i in j + 1..NUM_VALUES {
+            if values[i] < values[min] {
                 // Found a new minimum. Keep the index
                 min = i;
             }
         }
 
         // If a minimum was found, swap it
-        if min != j
-        {
+        if min != j {
             let val1 = values[min];
             let val2 = values[j];
             values[min] = val2;


### PR DESCRIPTION
Set up so the repo can be built with cargo, e.g. with `cargo run` / `cargo build` / `cargo test`. The new main function in `main.rs` will call the `main` functions for all the sort functions. 

Could later replace the other main functions with #test functions in `main.rs` potentially instead.

Also ran the code through `cargo fmt` which runs [rustfmt](https://github.com/rust-lang-nursery/rustfmt) with default settings to follow the general Rust code standards, one can customise that one more also if one want with a `rustfmt.toml`, but would recommend just keeping it as standard for now while learning.

Finally I did some smaller improvements to the merge sort to allow it to use dynamic vectors instead of just fixed ones together with an optimisation/simplification of using `copy_from_slice` instead of manually looping through elements to copy

Enjoy :)